### PR TITLE
Parallel computation for null model using 'mclapply'

### DIFF
--- a/CohesionScript_v1.1
+++ b/CohesionScript_v1.1
@@ -171,6 +171,7 @@ if(tax.shuffle) {
   }, mc.cores=ncores))
  }
 }
+}
   
 # Save observed minus expected correlations. Use custom correlations if use.custom.cors = TRUE
 if(use.custom.cors == T) {

--- a/CohesionScript_v1.1
+++ b/CohesionScript_v1.1
@@ -50,6 +50,8 @@ tax.shuffle <- T
 # There should be no empty (all zero) taxon vectors in the abundance table. 
 # Even if you input your own correlation table, the persistence cutoff will be applied
 use.custom.cors <- F
+## Number of cores to use for 'mclapply' [set ncores=1 if deterministic results desired]
+ncores <- 16
 
 ###################################################################
 ###################################################################
@@ -100,33 +102,24 @@ hist(rowSums(rel.d))
 # Create observed correlation matrix
 cor.mat.true <- cor(rel.d)
 
-# Create vector to hold median otu-otu correlations for initial otu
-med.tax.cors <- vector()
+# set a seed
+set.seed(sum(dim(rel.d)))
 
 # Run this loop for the null model to get expected pairwise correlations
 # Bypass null model if the option to input custom correlation matrix is TRUE
 if(use.custom.cors == F) {
 if(tax.shuffle) {
-  for(which.taxon in 1:dim(rel.d)[2]){
+  med.tax.cors <- do.call(cbind, mclapply(1:ncol(rel.d), function(which.taxon) {
     
     #create vector to hold correlations from every permutation for each single otu
     ## perm.cor.vec.mat stands for permuted correlations vector matrix
     perm.cor.vec.mat <- vector()
     
     for(i in 1:iter){
-      #Create empty matrix of same dimension as rel.d
-      perm.rel.d <- matrix(numeric(0), dim(rel.d)[1], dim(rel.d)[2])
+      # create permuted matrix (with which.taxon column fixed)
+      perm.rel.d <- apply(rel.d, 2, sample)
+      perm.rel.d[, which.taxon] <- rel.d[, which.taxon]
       rownames(perm.rel.d) <- rownames(rel.d)
-      colnames(perm.rel.d) <- colnames(rel.d)
-      
-      #For each otu
-      for(j in 1:dim(rel.d)[2]){ 
-        # Replace the original taxon vector with a permuted taxon vector
-        perm.rel.d[, j ] <- sample(rel.d[ ,j ]) 
-      }
-      
-      # Do not randomize focal column 
-      perm.rel.d[, which.taxon] <- rel.d[ , which.taxon]
       
       # Calculate correlation matrix of permuted matrix
       cor.mat.null <- cor(perm.rel.d)
@@ -135,14 +128,15 @@ if(tax.shuffle) {
       perm.cor.vec.mat <- cbind(perm.cor.vec.mat, cor.mat.null[, which.taxon])
       
     }
-    # Save the median correlations between the focal taxon and all other taxa  
-    med.tax.cors <- cbind(med.tax.cors, apply(perm.cor.vec.mat, 1, median))
-    
     # For large datasets, this can be helpful to know how long this loop will run
     if(which.taxon %% 20 == 0){print(which.taxon)}
-  }
+    
+    # Save the median correlations between the focal taxon and all other taxa  
+    apply(perm.cor.vec.mat, 1, median)
+    
+  }, mc.cores=ncores))
 } else {
-  for(which.taxon in 1:dim(rel.d)[2]){
+  med.tax.cors <- do.call(cbind, mclapply(1:ncol(rel.d), function(which.taxon) {
     
     #create vector to hold correlations from every permutation for each single otu
     ## perm.cor.vec.mat stands for permuted correlations vector matrix
@@ -169,12 +163,12 @@ if(tax.shuffle) {
       perm.cor.vec.mat <- cbind(perm.cor.vec.mat, cor.mat.null[, which.taxon])
       
     }
-    # Save the median correlations between the focal taxon and all other taxa  
-    med.tax.cors <- cbind(med.tax.cors, apply(perm.cor.vec.mat, 1, median))
-    
     # For large datasets, this can be helpful to know how long this loop will run
     if(which.taxon %% 20 == 0){print(which.taxon)}
-  }
+    
+    # Save the median correlations between the focal taxon and all other taxa  
+    apply(perm.cor.vec.mat, 1, median)
+  }, mc.cores=ncores))
  }
 }
   


### PR DESCRIPTION
Hi,

Small modifications to use `mclapply` to parallelize computation of the null model. Option to set ncores=1 if deterministic results are desired, with a line to set a random seed.

Tested with `ncores=1` to obtain identical results as no `mclapply`